### PR TITLE
Enable runtime z-offset controll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Config Files/eddy.cfg
+++ b/Config Files/eddy.cfg
@@ -67,8 +67,8 @@ speed: 200
 
 
 # Uncomment this if you are using Eddy as the probe AND the homing endstop AND would like to use the beta z-offset control
-#[save_variables]
-#filename: ~/printer_data/config/variables.cfg
+[save_variables]
+filename: ~/printer_data/config/variables.cfg
 
 
 
@@ -79,14 +79,14 @@ enable_force_move: True # Allows a user to move the z axis down if they have no 
 
 
 # Uncomment this if you are using Eddy as the probe AND the homing endstop AND would like to use the beta z-offset control
-#[delayed_gcode RESTORE_PROBE_OFFSET]
-#initial_duration: 1.
-#gcode:
-#  {% set svv = printer.save_variables.variables %}
-#  {% if not printer["gcode_macro SET_GCODE_OFFSET"].restored %}
-#    SET_GCODE_VARIABLE MACRO=SET_GCODE_OFFSET VARIABLE=runtime_offset VALUE={ svv.nvm_offset|default(0) }
-#    SET_GCODE_VARIABLE MACRO=SET_GCODE_OFFSET VARIABLE=restored VALUE=True
-#  {% endif %}
+[delayed_gcode RESTORE_PROBE_OFFSET]
+initial_duration: 1.
+gcode:
+ {% set svv = printer.save_variables.variables %}
+ {% if not printer["gcode_macro SET_GCODE_OFFSET"].restored %}
+   SET_GCODE_VARIABLE MACRO=SET_GCODE_OFFSET VARIABLE=runtime_offset VALUE={ svv.nvm_offset|default(0) }
+   SET_GCODE_VARIABLE MACRO=SET_GCODE_OFFSET VARIABLE=restored VALUE=True
+ {% endif %}
 
 
 
@@ -115,11 +115,11 @@ gcode:
 
 
 # Uncomment this if you are using Eddy as the probe AND the homing endstop AND would like to use the beta z-offset control
-#[gcode_macro Z_OFFSET_APPLY_PROBE]
-#rename_existing: Z_OFFSET_APPLY_PROBE_ORIG
-#gcode:
-#  SAVE_VARIABLE VARIABLE=nvm_offset VALUE={ printer["gcode_macro SET_GCODE_OFFSET"].runtime_offset }
-
+[gcode_macro Z_OFFSET_APPLY_PROBE]
+rename_existing: Z_OFFSET_APPLY_PROBE_ORIG
+gcode:
+  SAVE_VARIABLE VARIABLE=nvm_offset VALUE={ printer["gcode_macro SET_GCODE_OFFSET"].runtime_offset }
+  
 
 
 # Uncomment the lines in this macro if you are using Eddy as the probe AND the homing endstop AND would like to use the beta z-offset control
@@ -128,21 +128,9 @@ rename_existing: SET_GCODE_OFFSET_ORIG
 variable_restored: False  # Mark whether the var has been restored from NVM
 variable_runtime_offset: 0
 gcode:
-#  {% if params.Z_ADJUST %}
-#    SET_GCODE_VARIABLE MACRO=SET_GCODE_OFFSET VARIABLE=runtime_offset VALUE={ printer["gcode_macro SET_GCODE_OFFSET"].runtime_offset + params.Z_ADJUST|float }
-#  {% endif %}
-#  {% if params.Z %}
-#    {% set paramList = rawparams.split() %}
-#    {% for i in range(paramList|length) %}
-#      {% if paramList[i]=="Z=0" %}
-#        {% set temp=paramList.pop(i) %}
-#        {% set temp="Z_ADJUST=" + (-printer["gcode_macro SET_GCODE_OFFSET"].runtime_offset)|string %}
-#        {% if paramList.append(temp) %}{% endif %}
-#      {% endif %}
-#    {% endfor %}
-#    {% set rawparams=paramList|join(' ') %}
-#    SET_GCODE_VARIABLE MACRO=SET_GCODE_OFFSET VARIABLE=runtime_offset VALUE=0
-#  {% endif %}
+  {% if params.Z_ADJUST %}
+    SET_GCODE_VARIABLE MACRO=SET_GCODE_OFFSET VARIABLE=runtime_offset VALUE={ printer["gcode_macro SET_GCODE_OFFSET"].runtime_offset + params.Z_ADJUST|float }
+  {% endif %}
   SET_GCODE_OFFSET_ORIG { rawparams }
 
 

--- a/Config Files/macros.cfg
+++ b/Config Files/macros.cfg
@@ -43,13 +43,14 @@ gcode:
 description: Pause the actual running print
 rename_existing: PAUSE_BASE
 gcode:
+  SAVE_GCODE_STATE NAME=PAUSE
   PAUSE_BASE
   G91
   G1 Z20 F3000
   G90
   G1 X200 Y5 F12000
   SET_IDLE_TIMEOUT TIMEOUT=86400 #one day in seconds
-
+  RESTORE_GCODE_STATE NAME=PAUSE
 
 [gcode_macro RESUME]
 description: Resume the actual running print
@@ -120,6 +121,7 @@ gcode:
 
 [gcode_macro _WIPE]
 gcode:
+  SAVE_GCODE_STATE NAME=_WIPE
   {% if printer[printer.toolhead.extruder].temperature >= 165 %}
   G92 E0
   G0 E-0.5 F5000
@@ -131,6 +133,7 @@ gcode:
   G1 X+12 F3500
   G1 X-12 F3500
   G90
+  RESTORE_GCODE_STATE NAME=_WIPE
 
 [gcode_macro _RETRACT]
 gcode:
@@ -142,19 +145,17 @@ gcode:
 
 [gcode_macro _ZHOP]
 gcode:
+  SAVE_GCODE_STATE NAME=_ZHOP
   {% if printer.idle_timeout.state == "Printing" %}
   G91
   G1 Z1 F2000
   G90
   {% endif %}
-
-
-
-
-
+  RESTORE_GCODE_STATE NAME=_ZHOP
 
 [gcode_macro SELECT_T0]
 gcode:
+  SAVE_GCODE_STATE NAME=SELECT_T0
   {% set svv = printer.save_variables.variables %}
   T0
   G0 Y{svv.zero_select_y} F30000
@@ -166,14 +167,16 @@ gcode:
   _PRIME
   #_WIPE
   G0 X0 F12000
+  RESTORE_GCODE_STATE NAME=SELECT_T0  
   {% if "xyz" in printer.toolhead.homed_axes %}
   SET_GCODE_OFFSET X=0
   SET_GCODE_OFFSET Y=0
-  SET_GCODE_OFFSET Z=0
+  SET_GCODE_OFFSET Z={ printer["gcode_macro SET_GCODE_OFFSET"].runtime_offset }
   {% endif %} 
 
 [gcode_macro DOCK_T0]
 gcode:
+  SAVE_GCODE_STATE NAME=DOCK_T0
   {% set svv = printer.save_variables.variables %}
   _RETRACT
   _ZHOP
@@ -185,14 +188,12 @@ gcode:
   G0 Y{svv.zero_select_y} F4000
   G0 X{svv.zero_dock_x + 10} F12000
   G0 X15 F24000
+  RESTORE_GCODE_STATE NAME=DOCK_T0
+  _OFFSET_RESET
   
-
-
-
-
-
 [gcode_macro SELECT_T1]
 gcode:
+  SAVE_GCODE_STATE NAME=SELECT_T1
   {% set svv = printer.save_variables.variables %}
   T1
   G0 Y{svv.one_select_y} F30000
@@ -204,14 +205,16 @@ gcode:
   _PRIME
   #_WIPE
   G0 X0 F12000
+  RESTORE_GCODE_STATE NAME=SELECT_T1
   {% if "xyz" in printer.toolhead.homed_axes %}
   SET_GCODE_OFFSET X={svv.one_x_offset}
   SET_GCODE_OFFSET Y={svv.one_y_offset}
-  SET_GCODE_OFFSET Z={svv.one_z_offset}
+  SET_GCODE_OFFSET Z={svv.one_z_offset + printer["gcode_macro SET_GCODE_OFFSET"].runtime_offset }
   {% endif %} 
 
 [gcode_macro DOCK_T1]
 gcode:
+  SAVE_GCODE_STATE NAME=DOCK_T1
   {% set svv = printer.save_variables.variables %}
   _RETRACT
   _ZHOP
@@ -223,14 +226,12 @@ gcode:
   G0 Y{svv.one_select_y} F4000
   G0 X{svv.one_dock_x + 10} F12000
   G0 X15 F24000
-
-
-
-
-
+  RESTORE_GCODE_STATE NAME=DOCK_T1
+  _OFFSET_RESET
 
 [gcode_macro SELECT_T2]
 gcode:
+  SAVE_GCODE_STATE NAME=SELECT_T2
   {% set svv = printer.save_variables.variables %}
   T2
   G0 Y{svv.two_select_y} F30000
@@ -242,14 +243,16 @@ gcode:
   _PRIME
   #_WIPE
   G0 X0 F12000
+  RESTORE_GCODE_STATE NAME=SELECT_T2
   {% if "xyz" in printer.toolhead.homed_axes %}
   SET_GCODE_OFFSET X={svv.two_x_offset}
   SET_GCODE_OFFSET Y={svv.two_y_offset}
-  SET_GCODE_OFFSET Z={svv.two_z_offset}
+  SET_GCODE_OFFSET Z={svv.two_z_offset + printer["gcode_macro SET_GCODE_OFFSET"].runtime_offset }
   {% endif %} 
 
 [gcode_macro DOCK_T2]
 gcode:
+  SAVE_GCODE_STATE NAME=DOCK_T2
   {% set svv = printer.save_variables.variables %}
   _RETRACT
   _ZHOP
@@ -261,7 +264,8 @@ gcode:
   G0 Y{svv.two_select_y} F4000
   G0 X{svv.two_dock_x + 15} F12000
   G0 X15 F24000
-  
+  RESTORE_GCODE_STATE NAME=DOCK_T2
+  _OFFSET_RESET
 
 
 

--- a/Config Files/variables.cfg
+++ b/Config Files/variables.cfg
@@ -61,3 +61,5 @@ two_x_offset = 0
 two_y_offset = 0
 two_z_offset = 0
 
+# runtime z-offset will be stored here
+nvm_offset = 0


### PR DESCRIPTION
With current config it is impossible to fine tune z-offset (probe offset) during print when multiple extruders are used. The offset will be reset on current extruder docking. As a result next extruder will start extruding to high or too low, potentially damaging the print surface of a model.

This PR makes it possible to tune the offset in runtime (AKA bebystepping) and save it to variables (with `Z_OFFSET_APPLY_PROBE` macro).
Offset will be applied to all printheads (since this is the probe offset).

Tuning z-offset in runtime could be helpful in multiple occasions. 

- The inductive probe could be inaccurate in some conditions (highly depend on ambient temperature, bed temperature, coil temperature).
- The inductive probe measures distance to a steal plate rather than to actual print surface. That could be a problem when multiple print surfaces are in use each one having different coating (PEI sheets could be far thicker than average first layer hight).