### PR TITLE
Don't cancel every print

### DIFF
--- a/Config Files/macros.cfg
+++ b/Config Files/macros.cfg
@@ -29,15 +29,15 @@ gcode:
     # Disable steppers
     M84
     BED_MESH_CLEAR
-    CANCEL_PRINT_BASE
 
 
 [gcode_macro CANCEL_PRINT]
 description: Cancel the actual running print
 rename_existing: CANCEL_PRINT_BASE
 gcode:
+  CLEAR_PAUSE
   _END_PRINT
-
+  CANCEL_PRINT_BASE
 
 [gcode_macro PAUSE]
 description: Pause the actual running print


### PR DESCRIPTION
The `CANCEL_PRINT` macro is being executed on every print end.
This causes every print job in Klipper UI displayed as 'Canceled' even though it was successfully completed.